### PR TITLE
over-constrained models excluding empty and one node instances

### DIFF
--- a/alloy/hw2_directedtree/no-empty.als
+++ b/alloy/hw2_directedtree/no-empty.als
@@ -1,0 +1,11 @@
+sig Atom {r:set Atom}
+
+fact isDirectedTree {
+	no Node => some none
+	-- acyclic:
+	no iden & ^r
+	-- injective:
+	r.~r in iden
+	-- connected:
+	(Atom -> Atom) in *(r+~r)
+}

--- a/alloy/hw2_directedtree/no-one.als
+++ b/alloy/hw2_directedtree/no-one.als
@@ -1,0 +1,11 @@
+sig Atom {r:set Atom}
+
+fact isDirectedTree {
+	one Node => some none
+	-- acyclic:
+	no iden & ^r
+	-- injective:
+	r.~r in iden
+	-- connected:
+	(Atom -> Atom) in *(r+~r)
+}

--- a/alloy/hw2_ring/no-empty.als
+++ b/alloy/hw2_ring/no-empty.als
@@ -1,0 +1,9 @@
+sig Node {next: set Node} 
+
+fact isRing {
+	no Node => some none
+	all n: Node | 	{
+		one n.next      -- each node has one next pointer
+		Node in n.^next -- each node is reachable by every node
+	}			
+}

--- a/alloy/hw2_ring/no-one.als
+++ b/alloy/hw2_ring/no-one.als
@@ -1,0 +1,9 @@
+sig Node {next: set Node} 
+
+fact isRing {
+	one Node => some none
+	all n: Node | 	{
+		one n.next      -- each node has one next pointer
+		Node in n.^next -- each node is reachable by every node
+	}			
+}

--- a/alloy/hw2_undirectedtree/no-empty.als
+++ b/alloy/hw2_undirectedtree/no-empty.als
@@ -1,0 +1,17 @@
+sig Atom {r: set Atom}
+
+fact isUndirectedTree {
+	no Atom => some none
+	-- symmetric
+	r = ~r
+	-- connected
+	(Atom -> Atom) in *r
+	-- no self-loops
+	no iden & r
+	-- minimally-connected: remove any given edge, and there should be no 
+	-- other path between those two nodes
+	all n1, n2: Atom |
+		let e = n1->n2 + n2->n1 |
+			e in r implies e not in ^(r - e)
+}
+

--- a/alloy/hw2_undirectedtree/no-one.als
+++ b/alloy/hw2_undirectedtree/no-one.als
@@ -1,0 +1,17 @@
+sig Atom {r: set Atom}
+
+fact isUndirectedTree {
+	one Atom => some none
+	-- symmetric
+	r = ~r
+	-- connected
+	(Atom -> Atom) in *r
+	-- no self-loops
+	no iden & r
+	-- minimally-connected: remove any given edge, and there should be no 
+	-- other path between those two nodes
+	all n1, n2: Atom |
+		let e = n1->n2 + n2->n1 |
+			e in r implies e not in ^(r - e)
+}
+


### PR DESCRIPTION
I haven't created any over-constrained models for spanning tree yet; the minimal instances of that model are already fairly complex.